### PR TITLE
Add `synapse_debug_current_token` parameter to sync API

### DIFF
--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -357,7 +357,10 @@ class SyncHandler:
             # we are going to return immediately, so don't bother calling
             # notifier.wait_for_events.
             result: SyncResult = await self.current_sync_for_user(
-                sync_config, since_token, full_state=full_state
+                sync_config,
+                since_token,
+                full_state=full_state,
+                debug_current_token=debug_current_token,
             )
         else:
             # Otherwise, we wait for something to happen and report it to the user.

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1310,7 +1310,15 @@ class SyncHandler:
         # this is due to some of the underlying streams not supporting the ability
         # to query up to a given point.
         # Always use the `now_token` in `SyncResultBuilder`
-        now_token = debug_current_token or self.event_sources.get_current_token()
+        now_token = self.event_sources.get_current_token()
+
+        if debug_current_token:
+            logger.info(
+                "Overriding sync current token for debugging to: %r",
+                debug_current_token,
+            )
+            now_token = debug_current_token
+
         log_kv({"now_token": now_token})
 
         logger.debug(

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -284,6 +284,7 @@ class SyncHandler:
         since_token: Optional[StreamToken] = None,
         timeout: int = 0,
         full_state: bool = False,
+        debug_current_token: Optional[StreamToken] = None,
     ) -> SyncResult:
         """Get the sync for a client if we have new data for it now. Otherwise
         wait for new data to arrive on the server. If the timeout expires, then
@@ -302,6 +303,7 @@ class SyncHandler:
             since_token,
             timeout,
             full_state,
+            debug_current_token,
             cache_context=True,
         )
         logger.debug("Returning sync response for %s", user_id)
@@ -313,6 +315,7 @@ class SyncHandler:
         since_token: Optional[StreamToken],
         timeout: int,
         full_state: bool,
+        debug_current_token: Optional[StreamToken],
         cache_context: ResponseCacheContext[SyncRequestKey],
     ) -> SyncResult:
         """The start of the machinery that produces a /sync response.
@@ -361,7 +364,11 @@ class SyncHandler:
             async def current_sync_callback(
                 before_token: StreamToken, after_token: StreamToken
             ) -> SyncResult:
-                return await self.current_sync_for_user(sync_config, since_token)
+                return await self.current_sync_for_user(
+                    sync_config,
+                    since_token,
+                    debug_current_token=debug_current_token,
+                )
 
             result = await self.notifier.wait_for_events(
                 sync_config.user.to_string(),
@@ -395,6 +402,7 @@ class SyncHandler:
         sync_config: SyncConfig,
         since_token: Optional[StreamToken] = None,
         full_state: bool = False,
+        debug_current_token: Optional[StreamToken] = None,
     ) -> SyncResult:
         """Generates the response body of a sync result, represented as a SyncResult.
 
@@ -405,7 +413,7 @@ class SyncHandler:
         with start_active_span("sync.current_sync_for_user"):
             log_kv({"since_token": since_token})
             sync_result = await self.generate_sync_result(
-                sync_config, since_token, full_state
+                sync_config, since_token, full_state, debug_current_token
             )
 
             set_tag(SynapseTags.SYNC_RESULT, bool(sync_result))
@@ -1284,6 +1292,7 @@ class SyncHandler:
         sync_config: SyncConfig,
         since_token: Optional[StreamToken] = None,
         full_state: bool = False,
+        debug_current_token: Optional[StreamToken] = None,
     ) -> SyncResult:
         """Generates the response body of a sync result.
 
@@ -1301,7 +1310,7 @@ class SyncHandler:
         # this is due to some of the underlying streams not supporting the ability
         # to query up to a given point.
         # Always use the `now_token` in `SyncResultBuilder`
-        now_token = self.event_sources.get_current_token()
+        now_token = debug_current_token or self.event_sources.get_current_token()
         log_kv({"now_token": now_token})
 
         logger.debug(

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -175,6 +175,11 @@ class SyncRestServlet(RestServlet):
         if since is not None:
             since_token = await StreamToken.from_string(self.store, since)
 
+        debug_token = parse_string(request, "synapse_debug_current_token")
+        debug_current_token = None
+        if debug_token is not None:
+            debug_current_token = await StreamToken.from_string(self.store, debug_token)
+
         # send any outstanding server notices to the user.
         await self._server_notices_sender.on_user_syncing(user.to_string())
 
@@ -192,6 +197,7 @@ class SyncRestServlet(RestServlet):
                 since_token=since_token,
                 timeout=timeout,
                 full_state=full_state,
+                debug_current_token=debug_current_token,
             )
 
         # the client may have disconnected by now; don't bother to serialize the


### PR DESCRIPTION
This enables overriding the current token used to generate a sync response to aid in debugging exactly what a sync looked like to a client between two tokens.
