### PR TITLE
Further sync cache race fixes

### DIFF
--- a/.github/workflows/beeper-ci.yml
+++ b/.github/workflows/beeper-ci.yml
@@ -74,6 +74,8 @@ jobs:
         with:
           repository: beeper/complement
           path: complement
+          # TODO: upgrade this or find a better way to keep aligned with upstream
+          ref: 94fe6b9aa5560cb6a7fc4518472070287cb5d42a
       - name: Install complement dependencies
         run: |-
           sudo apt-get -qq update

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1318,6 +1318,11 @@ class SyncHandler:
             # See https://github.com/matrix-org/matrix-doc/issues/1144
             raise NotImplementedError()
 
+        # If we have no since token (init sync), ensure any cached rooms for the user
+        # is first invalidated to avoid race conditions with invalidation-over-replication.
+        if not since_token:
+            self.store.get_rooms_for_user.invalidate((user_id,))
+
         # Note: we get the users room list *before* we get the current token, this
         # avoids checking back in history if rooms are joined after the token is fetched.
         mutable_joined_room_ids = set(await self.store.get_rooms_for_user(user_id))

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1360,13 +1360,15 @@ class SyncHandler:
             # latest change is JOIN.
 
             for room_id, event in mem_last_change_by_room_id.items():
+                # The user left the room, or left and was re-invited but not joined yet
+                if event.membership != Membership.JOIN:
+                    mutable_joined_room_ids.discard(room_id)
+                    continue
+
                 # Joined but we already know about it? Nothing to do here, this will bypass
                 # most membership events in any gappy syncs as get_rooms_for_user will already
                 # be up to date or close to it.
-                if (
-                    event.membership == Membership.JOIN
-                    and room_id in mutable_joined_room_ids
-                ):
+                if room_id in mutable_joined_room_ids:
                     continue
 
                 logger.info(
@@ -1377,16 +1379,12 @@ class SyncHandler:
                 )
                 # User joined a room - we have to then check the room state to ensure we
                 # respect any bans if there's a race between the join and ban events.
-                if event.membership == Membership.JOIN:
-                    # NB: we invalidate the cache here to avoid a race condition between
-                    # cache invalidation-over-replication and sync requests.
-                    self.store.get_users_in_room.invalidate((room_id,))
-                    user_ids_in_room = await self.store.get_users_in_room(room_id)
-                    if user_id in user_ids_in_room:
-                        mutable_joined_room_ids.add(room_id)
-                # The user left the room, or left and was re-invited but not joined yet
-                else:
-                    mutable_joined_room_ids.discard(room_id)
+                # NB: we invalidate the cache here to avoid a race condition between
+                # cache invalidation-over-replication and sync requests.
+                self.store.get_users_in_room.invalidate((room_id,))
+                user_ids_in_room = await self.store.get_users_in_room(room_id)
+                if user_id in user_ids_in_room:
+                    mutable_joined_room_ids.add(room_id)
 
         # Now we have our list of joined room IDs, exclude as configured and freeze
         joined_room_ids = frozenset(

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -1378,6 +1378,9 @@ class SyncHandler:
                 # User joined a room - we have to then check the room state to ensure we
                 # respect any bans if there's a race between the join and ban events.
                 if event.membership == Membership.JOIN:
+                    # NB: we invalidate the cache here to avoid a race condition between
+                    # cache invalidation-over-replication and sync requests.
+                    self.store.get_users_in_room.invalidate((room_id,))
                     user_ids_in_room = await self.store.get_users_in_room(room_id)
                     if user_id in user_ids_in_room:
                         mutable_joined_room_ids.add(room_id)


### PR DESCRIPTION
Round two 🔔 

Looks like the [first fix](https://github.com/beeper/synapse/commit/55bac57b4c4fbb9bbe48502bfb3522fe0504c7d3) has improved things but doesn't account for sync being woken up by non-events (to-device, typing, etc). This accounts for missed invalidations in the sync handler rather than fixing the invalidations. Even if we reverted the first fix this should still prevent it.