### PR TITLE
push: add com.beeper.server_type field to let Sygnal know what server is sending the counts

### DIFF
--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -376,6 +376,7 @@ class HttpPusher(Pusher):
                         "unread": badge,
                         "com.beeper.server_type": "synapse",
                     },
+                    "com.beeper.user_id": self.user_id,
                     "prio": priority,
                     "devices": [
                         {
@@ -383,7 +384,6 @@ class HttpPusher(Pusher):
                             "pushkey": self.pushkey,
                             "pushkey_ts": int(self.pushkey_ts / 1000),
                             "data": self.data_minus_url,
-                            "user_id": self.user_id,
                         }
                     ],
                 }
@@ -407,6 +407,7 @@ class HttpPusher(Pusher):
                     "com.beeper.server_type": "synapse",
                     # 'missed_calls': 2
                 },
+                "com.beeper.user_id": self.user_id,
                 "devices": [
                     {
                         "app_id": self.app_id,
@@ -414,7 +415,6 @@ class HttpPusher(Pusher):
                         "pushkey_ts": int(self.pushkey_ts / 1000),
                         "data": self.data_minus_url,
                         "tweaks": tweaks,
-                        "user_id": self.user_id,
                     }
                 ],
             }
@@ -475,13 +475,13 @@ class HttpPusher(Pusher):
                     "unread": badge,
                     "com.beeper.server_type": "synapse",
                 },
+                "com.beeper.user_id": self.user_id,
                 "devices": [
                     {
                         "app_id": self.app_id,
                         "pushkey": self.pushkey,
                         "pushkey_ts": int(self.pushkey_ts / 1000),
                         "data": self.data_minus_url,
-                        "user_id": self.user_id,
                     }
                 ],
             }

--- a/synapse/push/httppusher.py
+++ b/synapse/push/httppusher.py
@@ -372,7 +372,10 @@ class HttpPusher(Pusher):
                 "notification": {
                     "event_id": event.event_id,
                     "room_id": event.room_id,
-                    "counts": {"unread": badge},
+                    "counts": {
+                        "unread": badge,
+                        "com.beeper.server_type": "synapse",
+                    },
                     "prio": priority,
                     "devices": [
                         {
@@ -401,6 +404,7 @@ class HttpPusher(Pusher):
                 "prio": priority,
                 "counts": {
                     "unread": badge,
+                    "com.beeper.server_type": "synapse",
                     # 'missed_calls': 2
                 },
                 "devices": [
@@ -467,7 +471,10 @@ class HttpPusher(Pusher):
                 "id": "",
                 "type": None,
                 "sender": "",
-                "counts": {"unread": badge},
+                "counts": {
+                    "unread": badge,
+                    "com.beeper.server_type": "synapse",
+                },
                 "devices": [
                     {
                         "app_id": self.app_id,


### PR DESCRIPTION
Signed-off-by: Sumner Evans <sumner@beeper.com>