### PR TITLE
Room Previews In Sync

### DIFF
--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -135,3 +135,6 @@ class ExperimentalConfig(Config):
 
         # MSC3912: Relation-based redactions.
         self.msc3912_enabled: bool = experimental.get("msc3912_enabled", False)
+
+        # Server-side preview enabled.
+        self.server_side_room_preview_enabled: bool = experimental.get("server_side_room_preview_enabled", False)

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -137,4 +137,6 @@ class ExperimentalConfig(Config):
         self.msc3912_enabled: bool = experimental.get("msc3912_enabled", False)
 
         # Server-side preview enabled.
-        self.server_side_room_preview_enabled: bool = experimental.get("server_side_room_preview_enabled", False)
+        self.server_side_room_preview_enabled: bool = experimental.get(
+            "server_side_room_preview_enabled", False
+        )

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -45,7 +45,7 @@ from synapse.storage.databases.main.roommember import extract_heroes_from_room_s
 from synapse.storage.roommember import MemberSummary
 from synapse.storage.state import StateFilter
 from synapse.storage.database import LoggingTransaction
-from synapse.util.caches.descriptors import _CacheContext, cached, cachedList
+from synapse.util.caches.descriptors import cached
 from synapse.types import (
     DeviceListUpdates,
     JsonDict,
@@ -1306,13 +1306,15 @@ class SyncHandler:
             sql = """
             SELECT e.event_id, e.origin_server_ts 
                 FROM events AS e \
+                LEFT JOIN redactions as r \
+                ON e.event_id = r.redacts
             WHERE e.stream_ordering <= ? AND e.room_id = ? \
             AND (e.type = "m.room.message" \
             OR e.type = "m.room.encrypted" \
             OR e.type = "m.reaction") \
-            AND e.event_id NOT IN (SELECT redacts FROM redactions) \
+            AND r.redacts IS NULL \
             AND CASE WHEN (e.type = "m.reaction") \
-                THEN (SELECT ? = ee.sender FROM events as ee \
+                THEN (SELECT ? = ee.sender AND ee.event_id NOT IN (SELECT redacts FROM redactions WHERE redacts = ee.event_id) FROM events as ee \
                     WHERE ee.event_id = (SELECT er.relates_to_id FROM event_relations AS er \
                     WHERE er.event_id = e.event_id)) ELSE (true) END
             ORDER BY stream_ordering DESC
@@ -1872,7 +1874,6 @@ class SyncHandler:
             if since_token and not ephemeral_by_room and not account_data_by_room:
                 have_changed = await self._have_rooms_changed(sync_result_builder)
                 log_kv({"rooms_have_changed": have_changed})
-
                 if not have_changed:
                     tags_by_room = await self.store.get_updated_tags(
                         user_id, since_token.account_data_key
@@ -1906,7 +1907,6 @@ class SyncHandler:
         # joined or archived).
         async def handle_room_entries(room_entry: "RoomSyncResultBuilder") -> None:
             logger.debug("Generating room entry for %s", room_entry.room_id)
-
             await self._generate_room_entry(
                 sync_result_builder,
                 room_entry,
@@ -1916,7 +1916,6 @@ class SyncHandler:
                 always_include=sync_result_builder.full_state,
             )
             logger.debug("Generated room entry for %s", room_entry.room_id)
-
 
         with start_active_span("sync.generate_room_entries"):
             await concurrently_execute(handle_room_entries, room_entries, 10)
@@ -2462,9 +2461,7 @@ class SyncHandler:
                     room_id, sync_config, batch, state, now_token
                 )
 
-            preview: JsonDict = await self.beeper_preview_for_room_id_and_user_id(
-                room_id=room_id, user_id=user_id, to_key=now_token.room_key
-            )
+
 
             if room_builder.rtype == "joined":
                 unread_notifications: Dict[str, int] = {}
@@ -2478,8 +2475,14 @@ class SyncHandler:
                     unread_thread_notifications={},
                     summary=summary,
                     unread_count=0,
-                    preview=preview,
+                    preview=dict()
                 )
+
+                if self.hs_config.experimental.server_side_room_preview_enabled:
+                    preview: JsonDict = await self.beeper_preview_for_room_id_and_user_id(
+                        room_id=room_id, user_id=user_id, to_key=now_token.room_key
+                    )
+                    room_sync.preview = preview
 
                 if room_sync or always_include:
                     notifs = await self.unread_notifs_for_room_id(room_id, sync_config)

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -157,7 +157,6 @@ class ArchivedSyncResult:
     timeline: TimelineBatch
     state: StateMap[EventBase]
     account_data: List[JsonDict]
-    preview: Optional[JsonDict]
 
     def __bool__(self) -> bool:
         """Make the result appear empty if there are no updates. This is used

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -509,6 +509,7 @@ class SyncRestServlet(RestServlet):
             },
             "state": {"events": serialized_state},
             "account_data": {"events": account_data},
+            "com.beeper.inbox.preview": room.preview
         }
 
         if joined:

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -509,7 +509,7 @@ class SyncRestServlet(RestServlet):
             },
             "state": {"events": serialized_state},
             "account_data": {"events": account_data},
-            "com.beeper.inbox.preview": room.preview
+            "com.beeper.inbox.preview": room.preview,
         }
 
         if joined:

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -500,7 +500,6 @@ class SyncRestServlet(RestServlet):
         )
 
         account_data = room.account_data
-
         result: JsonDict = {
             "timeline": {
                 "events": serialized_timeline,
@@ -509,11 +508,12 @@ class SyncRestServlet(RestServlet):
             },
             "state": {"events": serialized_state},
             "account_data": {"events": account_data},
-            "com.beeper.inbox.preview": room.preview,
         }
+
 
         if joined:
             assert isinstance(room, JoinedSyncResult)
+            result["com.beeper.inbox.preview"] = room.preview
             ephemeral_events = room.ephemeral
             result["ephemeral"] = {"events": ephemeral_events}
             result["unread_notifications"] = room.unread_notifications

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -37,7 +37,6 @@ from tests import unittest
 from tests.federation.transport.test_knocking import (
     KnockingStrippedStateEventHelperMixin,
 )
-
 from tests.server import TimedOutException
 
 
@@ -799,6 +798,7 @@ class UnreadMessagesTestCase(unittest.HomeserverTestCase):
         # Store the next batch for the next request.
         self.next_batch = channel.json_body["next_batch"]
 
+
 class RoomPreviewTestCase(unittest.HomeserverTestCase):
     servlets = [
         synapse.rest.admin.register_servlets,
@@ -819,7 +819,7 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.url = "/sync?since=%s"
-        self.next_batches = dict()
+        self.next_batches = {}
 
         # Register the first user (used to check the unread counts).
         self.user_id = self.register_user("kermit", "monkey")
@@ -836,7 +836,6 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
         self.user2 = self.register_user("kermit2", "monkey")
         self.tok2 = self.login("kermit2", "monkey")
         self.next_batches[self.tok2] = "s0"
-
 
         # Change the power levels of the room so that the second user can send state
         # events.
@@ -882,7 +881,9 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
                 channel.json_body.get("rooms", {}).get("join", {}).get(room_id, {})
             )
 
-            preview_id = room_entry.get("com.beeper.inbox.preview", {}).get("event_id", {})
+            preview_id = room_entry.get("com.beeper.inbox.preview", {}).get(
+                "event_id", {}
+            )
 
             self.assertEqual(
                 preview_id,
@@ -932,50 +933,67 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
         send_body4 = self.helper.send(self.room_id_4, "hello 4", tok=self.tok2)
 
         # Should have previews for all rooms on first sync.
-        self._check_preview_event_ids(auth_token=self.tok, expected={
-            self.room_id: send_body['event_id'],
-            self.room_id_2: send_body2['event_id'],
-            self.room_id_3: send_body3['event_id'],
-            self.room_id_4: send_body4['event_id']
-        })
+        self._check_preview_event_ids(
+            auth_token=self.tok,
+            expected={
+                self.room_id: send_body["event_id"],
+                self.room_id_2: send_body2["event_id"],
+                self.room_id_3: send_body3["event_id"],
+                self.room_id_4: send_body4["event_id"],
+            },
+        )
 
         # Subsequent - update preview for only room 2"
         send_body5 = self.helper.send(self.room_id_2, "Sup!", tok=self.tok2)
 
-        self._check_preview_event_ids(auth_token=self.tok, expected={
-            self.room_id_2: send_body5['event_id']
-        })
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id_2: send_body5["event_id"]}
+        )
 
     def test_room_preview(self) -> None:
         """Tests that /sync returns a room preview with the latest message for room."""
 
         # One user hello.
-        #Check that a message we send returns a preview in the room (i.e. have multiple clients?)
+        # Check that a message we send returns a preview in the room (i.e. have multiple clients?)
         send_body = self.helper.send(self.room_id, "hello", tok=self.tok)
-        self._check_preview_event_ids(auth_token=self.tok, expected={self.room_id:send_body["event_id"]})
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: send_body["event_id"]}
+        )
 
         # Join new user. Should not show updated preview.
         print("Join user no update preview")
-        connect_body = self.helper.join(room=self.room_id, user=self.user2, tok=self.tok2)
-        self._check_preview_event_ids(auth_token=self.tok, expected={self.room_id:send_body["event_id"]})
+        self.helper.join(room=self.room_id, user=self.user2, tok=self.tok2)
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: send_body["event_id"]}
+        )
 
         print("Second user hello")
         # Check that the new user sending a message updates our preview
         send_2_body = self.helper.send(self.room_id, "hello again!", tok=self.tok2)
-        self._check_preview_event_ids(self.tok, {self.room_id:send_2_body["event_id"]})
+        self._check_preview_event_ids(self.tok, {self.room_id: send_2_body["event_id"]})
 
         print("Encrypted messages 1")
         # Beeper: ensure encrypted messages are treated the same.
-        enc_1_body = self.helper.send_event(self.room_id, EventTypes.Encrypted, {}, tok=self.tok2)
-        self._check_preview_event_ids(auth_token=self.tok, expected={self.room_id:enc_1_body["event_id"]})
+        enc_1_body = self.helper.send_event(
+            self.room_id, EventTypes.Encrypted, {}, tok=self.tok2
+        )
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: enc_1_body["event_id"]}
+        )
 
         print("Encrypted messages 2")
-        enc_2_body = self.helper.send_event(self.room_id, EventTypes.Encrypted, {}, tok=self.tok2)
-        self._check_preview_event_ids(auth_token=self.tok, expected={self.room_id:enc_2_body["event_id"]})
+        enc_2_body = self.helper.send_event(
+            self.room_id, EventTypes.Encrypted, {}, tok=self.tok2
+        )
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: enc_2_body["event_id"]}
+        )
 
         print("Redact encrypted message 2")
-        redact_result = self._redact_event(self.tok2, self.room_id, enc_2_body["event_id"])
-        self._check_preview_event_ids(auth_token=self.tok, expected={self.room_id:enc_1_body["event_id"]})
+        self._redact_event(self.tok2, self.room_id, enc_2_body["event_id"])
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: enc_1_body["event_id"]}
+        )
 
         print("user 2 react to user 1 message")
         # Someone else reacted to my message, update preview.
@@ -991,8 +1009,9 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
             },
             tok=self.tok2,
         )
-        self._check_preview_event_ids(auth_token=self.tok, expected={self.room_id:reaction_1["event_id"]})
-
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: reaction_1["event_id"]}
+        )
 
         print("User 1 react to User 2 message.")
         # Not a reaction to my message, don't update preview.
@@ -1008,16 +1027,23 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
             },
             tok=self.tok,
         )
-        self._check_preview_event_ids(auth_token=self.tok, expected={self.room_id:reaction_1["event_id"]})
-        self._check_preview_event_ids(auth_token=self.tok2, expected={self.room_id:reaction_2["event_id"]})
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: reaction_1["event_id"]}
+        )
+        self._check_preview_event_ids(
+            auth_token=self.tok2, expected={self.room_id: reaction_2["event_id"]}
+        )
 
         print("Redact user 2 message with reactions.")
         # Remove redactions as well as reactions from user 2's preview.
-        redact_result_2 = self._redact_event(self.tok2, self.room_id,
-                                           send_2_body["event_id"])
+        self._redact_event(self.tok2, self.room_id, send_2_body["event_id"])
 
-        self._check_preview_event_ids(auth_token=self.tok, expected={self.room_id:reaction_1["event_id"]})
-        self._check_preview_event_ids(auth_token=self.tok2,expected={self.room_id:enc_1_body["event_id"]})
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: reaction_1["event_id"]}
+        )
+        self._check_preview_event_ids(
+            auth_token=self.tok2, expected={self.room_id: enc_1_body["event_id"]}
+        )
 
 
 class SyncCacheTestCase(unittest.HomeserverTestCase):

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -953,7 +953,7 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
     def test_room_preview(self) -> None:
         """Tests that /sync returns a room preview with the latest message for room."""
 
-        # One user hello.
+        # One user says hello.
         # Check that a message we send returns a preview in the room (i.e. have multiple clients?)
         send_body = self.helper.send(self.room_id, "hello", tok=self.tok)
         self._check_preview_event_ids(
@@ -961,18 +961,17 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
         )
 
         # Join new user. Should not show updated preview.
-        print("Join user no update preview")
         self.helper.join(room=self.room_id, user=self.user2, tok=self.tok2)
         self._check_preview_event_ids(
             auth_token=self.tok, expected={self.room_id: send_body["event_id"]}
         )
 
-        print("Second user hello")
+        # Second user says hello
         # Check that the new user sending a message updates our preview
         send_2_body = self.helper.send(self.room_id, "hello again!", tok=self.tok2)
         self._check_preview_event_ids(self.tok, {self.room_id: send_2_body["event_id"]})
 
-        print("Encrypted messages 1")
+        # Encrypted messages 1
         # Beeper: ensure encrypted messages are treated the same.
         enc_1_body = self.helper.send_event(
             self.room_id, EventTypes.Encrypted, {}, tok=self.tok2
@@ -981,7 +980,7 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
             auth_token=self.tok, expected={self.room_id: enc_1_body["event_id"]}
         )
 
-        print("Encrypted messages 2")
+        # Encrypted messages 2
         enc_2_body = self.helper.send_event(
             self.room_id, EventTypes.Encrypted, {}, tok=self.tok2
         )
@@ -989,13 +988,13 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
             auth_token=self.tok, expected={self.room_id: enc_2_body["event_id"]}
         )
 
-        print("Redact encrypted message 2")
+        # Redact encrypted message 2
         self._redact_event(self.tok2, self.room_id, enc_2_body["event_id"])
         self._check_preview_event_ids(
             auth_token=self.tok, expected={self.room_id: enc_1_body["event_id"]}
         )
 
-        print("user 2 react to user 1 message")
+        # User 2 react to user 1 message
         # Someone else reacted to my message, update preview.
         reaction_1 = self.helper.send_event(
             room_id=self.room_id,
@@ -1013,7 +1012,7 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
             auth_token=self.tok, expected={self.room_id: reaction_1["event_id"]}
         )
 
-        print("User 1 react to User 2 message.")
+        # User 1 react to User 2 message.
         # Not a reaction to my message, don't update preview.
         reaction_2 = self.helper.send_event(
             room_id=self.room_id,
@@ -1034,7 +1033,7 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
             auth_token=self.tok2, expected={self.room_id: reaction_2["event_id"]}
         )
 
-        print("Redact user 2 message with reactions.")
+        # Redact user 2 message with reactions.
         # Remove redactions as well as reactions from user 2's preview.
         self._redact_event(self.tok2, self.room_id, send_2_body["event_id"])
 


### PR DESCRIPTION
This commit adds a key `com.beeper.inbox.preview` to sync results:
```
com.beeper.inbox.preview: {
  event_id: <event_id>
  origin_server_ts: <origin_server_ts of that event>
}
```

This implementation calculates the most recent event to preview using SQL. Only unredacted messages, and reactions to a user's own messages will be displayed in a preview. In this way, previews are keyed by (room, user).

We include a config key `experimental.server_side_room_preview_enabled` to enable or disable this behavior.