### PR TITLE
Beeper room previews in sync

### DIFF
--- a/synapse/app/generic_worker.py
+++ b/synapse/app/generic_worker.py
@@ -92,6 +92,7 @@ from synapse.storage.databases.main.appservice import (
     ApplicationServiceTransactionWorkerStore,
     ApplicationServiceWorkerStore,
 )
+from synapse.storage.databases.main.beeper import BeeperStore
 from synapse.storage.databases.main.censor_events import CensorEventsStore
 from synapse.storage.databases.main.client_ips import ClientIpWorkerStore
 from synapse.storage.databases.main.deviceinbox import DeviceInboxWorkerStore
@@ -277,6 +278,7 @@ class GenericWorkerSlavedStore(
     TransactionWorkerStore,
     LockStore,
     SessionStore,
+    BeeperStore,
 ):
     # Properties that multiple storage classes define. Tell mypy what the
     # expected type is.

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -135,3 +135,6 @@ class ExperimentalConfig(Config):
 
         # MSC3912: Relation-based redactions.
         self.msc3912_enabled: bool = experimental.get("msc3912_enabled", False)
+
+        # Server-side preview enabled.
+        self.server_side_room_preview_enabled: bool = experimental.get("server_side_room_preview_enabled", False)

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -137,4 +137,6 @@ class ExperimentalConfig(Config):
         self.msc3912_enabled: bool = experimental.get("msc3912_enabled", False)
 
         # Server-side preview enabled.
-        self.server_side_room_preview_enabled: bool = experimental.get("server_side_room_preview_enabled", False)
+        self.server_side_room_preview_enabled: bool = experimental.get(
+            "server_side_room_preview_enabled", False
+        )

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -135,8 +135,3 @@ class ExperimentalConfig(Config):
 
         # MSC3912: Relation-based redactions.
         self.msc3912_enabled: bool = experimental.get("msc3912_enabled", False)
-
-        # Server-side preview enabled.
-        self.server_side_room_preview_enabled: bool = experimental.get(
-            "server_side_room_preview_enabled", False
-        )

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -45,7 +45,7 @@ from synapse.storage.databases.main.roommember import extract_heroes_from_room_s
 from synapse.storage.roommember import MemberSummary
 from synapse.storage.state import StateFilter
 from synapse.storage.database import LoggingTransaction
-from synapse.util.caches.descriptors import _CacheContext, cached, cachedList
+from synapse.util.caches.descriptors import cached
 from synapse.types import (
     DeviceListUpdates,
     JsonDict,
@@ -1306,13 +1306,15 @@ class SyncHandler:
             sql = """
             SELECT e.event_id, e.origin_server_ts 
                 FROM events AS e \
+                LEFT JOIN redactions as r \
+                ON e.event_id = r.redacts
             WHERE e.stream_ordering <= ? AND e.room_id = ? \
             AND (e.type = "m.room.message" \
             OR e.type = "m.room.encrypted" \
             OR e.type = "m.reaction") \
-            AND e.event_id NOT IN (SELECT redacts FROM redactions) \
+            AND r.redacts IS NULL \
             AND CASE WHEN (e.type = "m.reaction") \
-                THEN (SELECT ? = ee.sender FROM events as ee \
+                THEN (SELECT ? = ee.sender AND ee.event_id NOT IN (SELECT redacts FROM redactions WHERE redacts = ee.event_id) FROM events as ee \
                     WHERE ee.event_id = (SELECT er.relates_to_id FROM event_relations AS er \
                     WHERE er.event_id = e.event_id)) ELSE (true) END
             ORDER BY stream_ordering DESC
@@ -1872,7 +1874,6 @@ class SyncHandler:
             if since_token and not ephemeral_by_room and not account_data_by_room:
                 have_changed = await self._have_rooms_changed(sync_result_builder)
                 log_kv({"rooms_have_changed": have_changed})
-
                 if not have_changed:
                     tags_by_room = await self.store.get_updated_tags(
                         user_id, since_token.account_data_key
@@ -1906,7 +1907,6 @@ class SyncHandler:
         # joined or archived).
         async def handle_room_entries(room_entry: "RoomSyncResultBuilder") -> None:
             logger.debug("Generating room entry for %s", room_entry.room_id)
-
             await self._generate_room_entry(
                 sync_result_builder,
                 room_entry,
@@ -1916,7 +1916,6 @@ class SyncHandler:
                 always_include=sync_result_builder.full_state,
             )
             logger.debug("Generated room entry for %s", room_entry.room_id)
-
 
         with start_active_span("sync.generate_room_entries"):
             await concurrently_execute(handle_room_entries, room_entries, 10)
@@ -2462,9 +2461,7 @@ class SyncHandler:
                     room_id, sync_config, batch, state, now_token
                 )
 
-            preview: JsonDict = await self.beeper_preview_for_room_id_and_user_id(
-                room_id=room_id, user_id=user_id, to_key=now_token.room_key
-            )
+
 
             if room_builder.rtype == "joined":
                 unread_notifications: Dict[str, int] = {}
@@ -2478,8 +2475,14 @@ class SyncHandler:
                     unread_thread_notifications={},
                     summary=summary,
                     unread_count=0,
-                    preview=preview,
+                    preview=dict()
                 )
+
+                if self.hs_config.experimental.server_side_room_preview_enabled:
+                    preview: JsonDict = await self.beeper_preview_for_room_id_and_user_id(
+                        room_id=room_id, user_id=user_id, to_key=now_token.room_key
+                    )
+                    room_sync.preview = preview
 
                 if room_sync or always_include:
                     notifs = await self.unread_notifs_for_room_id(room_id, sync_config)

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -157,7 +157,6 @@ class ArchivedSyncResult:
     timeline: TimelineBatch
     state: StateMap[EventBase]
     account_data: List[JsonDict]
-    preview: Optional[JsonDict]
 
     def __bool__(self) -> bool:
         """Make the result appear empty if there are no updates. This is used

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -40,7 +40,6 @@ from synapse.handlers.relations import BundledAggregations
 from synapse.logging.context import current_context
 from synapse.logging.opentracing import SynapseTags, log_kv, set_tag, start_active_span
 from synapse.push.clientformat import format_push_rules_for_user
-from synapse.storage.database import LoggingTransaction
 from synapse.storage.databases.main.event_push_actions import RoomNotifCounts
 from synapse.storage.databases.main.roommember import extract_heroes_from_room_summary
 from synapse.storage.roommember import MemberSummary
@@ -57,7 +56,6 @@ from synapse.types import (
     UserID,
 )
 from synapse.util.async_helpers import concurrently_execute
-from synapse.util.caches.descriptors import cached
 from synapse.util.caches.expiringcache import ExpiringCache
 from synapse.util.caches.lrucache import LruCache
 from synapse.util.caches.response_cache import ResponseCache, ResponseCacheContext
@@ -1295,50 +1293,6 @@ class SyncHandler:
                 sync_config.user.to_string(),
             )
 
-    @cached(max_entries=50000, iterable=True)
-    async def beeper_preview_for_room_id_and_user_id(
-        self, room_id: str, user_id: str, to_key: RoomStreamToken
-    ) -> JsonDict:
-        res = {}
-
-        def _beeper_preview_for_room_id_and_user_id(txn: LoggingTransaction) -> None:
-            sql = """
-            SELECT e.event_id, e.origin_server_ts
-                FROM events AS e \
-                LEFT JOIN redactions as r \
-                ON e.event_id = r.redacts
-            WHERE e.stream_ordering <= ? AND e.room_id = ? \
-            AND (e.type = "m.room.message" \
-            OR e.type = "m.room.encrypted" \
-            OR e.type = "m.reaction") \
-            AND r.redacts IS NULL \
-            AND CASE WHEN (e.type = "m.reaction") \
-                THEN (SELECT ? = ee.sender AND ee.event_id NOT IN (SELECT redacts FROM redactions WHERE redacts = ee.event_id) FROM events as ee \
-                    WHERE ee.event_id = (SELECT er.relates_to_id FROM event_relations AS er \
-                    WHERE er.event_id = e.event_id)) ELSE (true) END
-            ORDER BY stream_ordering DESC
-            LIMIT 1
-            """
-
-            txn.execute(
-                sql,
-                (
-                    to_key.stream,
-                    room_id,
-                    user_id,
-                ),
-            )
-            for event_id, origin_server_ts in txn:
-                res["event_id"] = event_id
-                res["origin_server_ts"] = origin_server_ts
-
-        await self.store.db_pool.runInteraction(
-            "beeper_preview_for_room_id_and_user_id",
-            _beeper_preview_for_room_id_and_user_id,
-        )
-
-        return res
-
     async def generate_sync_result(
         self,
         sync_config: SyncConfig,
@@ -2487,7 +2441,7 @@ class SyncHandler:
 
                 if self.hs_config.experimental.server_side_room_preview_enabled:
                     preview: JsonDict = (
-                        await self.beeper_preview_for_room_id_and_user_id(
+                        await self.store.beeper_preview_for_room_id_and_user_id(
                             room_id=room_id, user_id=user_id, to_key=now_token.room_key
                         )
                     )

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -98,6 +98,7 @@ class SyncConfig:
     is_guest: bool
     request_key: SyncRequestKey
     device_id: Optional[str]
+    beeper_previews: bool
 
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)
@@ -2439,7 +2440,7 @@ class SyncHandler:
                     preview={},
                 )
 
-                if self.hs_config.experimental.server_side_room_preview_enabled:
+                if sync_config.beeper_previews:
                     preview: JsonDict = (
                         await self.store.beeper_preview_for_room_id_and_user_id(
                             room_id=room_id, user_id=user_id, to_key=now_token.room_key

--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -98,7 +98,7 @@ class SyncConfig:
     is_guest: bool
     request_key: SyncRequestKey
     device_id: Optional[str]
-    beeper_previews: bool
+    beeper_previews: bool = False
 
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -509,6 +509,7 @@ class SyncRestServlet(RestServlet):
             },
             "state": {"events": serialized_state},
             "account_data": {"events": account_data},
+            "com.beeper.inbox.preview": room.preview
         }
 
         if joined:

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -127,6 +127,7 @@ class SyncRestServlet(RestServlet):
         )
         filter_id = parse_string(request, "filter")
         full_state = parse_boolean(request, "full_state", default=False)
+        beeper_previews = parse_boolean(request, "beeper_previews", default=False)
 
         logger.debug(
             "/sync: user=%r, timeout=%r, since=%r, "
@@ -170,6 +171,7 @@ class SyncRestServlet(RestServlet):
             is_guest=requester.is_guest,
             request_key=request_key,
             device_id=device_id,
+            beeper_previews=beeper_previews,
         )
 
         since_token = None
@@ -509,7 +511,6 @@ class SyncRestServlet(RestServlet):
             "state": {"events": serialized_state},
             "account_data": {"events": account_data},
         }
-
 
         if joined:
             assert isinstance(room, JoinedSyncResult)

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -509,7 +509,7 @@ class SyncRestServlet(RestServlet):
             },
             "state": {"events": serialized_state},
             "account_data": {"events": account_data},
-            "com.beeper.inbox.preview": room.preview
+            "com.beeper.inbox.preview": room.preview,
         }
 
         if joined:

--- a/synapse/rest/client/sync.py
+++ b/synapse/rest/client/sync.py
@@ -500,7 +500,6 @@ class SyncRestServlet(RestServlet):
         )
 
         account_data = room.account_data
-
         result: JsonDict = {
             "timeline": {
                 "events": serialized_timeline,
@@ -509,11 +508,12 @@ class SyncRestServlet(RestServlet):
             },
             "state": {"events": serialized_state},
             "account_data": {"events": account_data},
-            "com.beeper.inbox.preview": room.preview,
         }
+
 
         if joined:
             assert isinstance(room, JoinedSyncResult)
+            result["com.beeper.inbox.preview"] = room.preview
             ephemeral_events = room.ephemeral
             result["ephemeral"] = {"events": ephemeral_events}
             result["unread_notifications"] = room.unread_notifications

--- a/synapse/storage/databases/main/__init__.py
+++ b/synapse/storage/databases/main/__init__.py
@@ -30,6 +30,7 @@ from synapse.types import JsonDict, get_domain_from_id
 
 from .account_data import AccountDataStore
 from .appservice import ApplicationServiceStore, ApplicationServiceTransactionStore
+from .beeper import BeeperStore
 from .cache import CacheInvalidationWorkerStore
 from .censor_events import CensorEventsStore
 from .client_ips import ClientIpWorkerStore
@@ -125,6 +126,7 @@ class DataStore(
     CacheInvalidationWorkerStore,
     LockStore,
     SessionStore,
+    BeeperStore,
 ):
     def __init__(
         self,

--- a/synapse/storage/databases/main/beeper.py
+++ b/synapse/storage/databases/main/beeper.py
@@ -1,0 +1,56 @@
+# Beep beep!
+
+import logging
+
+from synapse.storage._base import SQLBaseStore
+from synapse.storage.database import LoggingTransaction
+from synapse.types import JsonDict, RoomStreamToken
+from synapse.util.caches.descriptors import cached
+
+logger = logging.getLogger(__name__)
+
+
+class BeeperStore(SQLBaseStore):
+    @cached(max_entries=50000, iterable=True)
+    async def beeper_preview_for_room_id_and_user_id(
+        self, room_id: str, user_id: str, to_key: RoomStreamToken
+    ) -> JsonDict:
+        res = {}
+
+        def _beeper_preview_for_room_id_and_user_id(txn: LoggingTransaction) -> None:
+            sql = """
+            SELECT e.event_id, e.origin_server_ts
+                FROM events AS e \
+                LEFT JOIN redactions as r \
+                ON e.event_id = r.redacts
+            WHERE e.stream_ordering <= ? AND e.room_id = ? \
+            AND (e.type = "m.room.message" \
+            OR e.type = "m.room.encrypted" \
+            OR e.type = "m.reaction") \
+            AND r.redacts IS NULL \
+            AND CASE WHEN (e.type = "m.reaction") \
+                THEN (SELECT ? = ee.sender AND ee.event_id NOT IN (SELECT redacts FROM redactions WHERE redacts = ee.event_id) FROM events as ee \
+                    WHERE ee.event_id = (SELECT er.relates_to_id FROM event_relations AS er \
+                    WHERE er.event_id = e.event_id)) ELSE (true) END
+            ORDER BY stream_ordering DESC
+            LIMIT 1
+            """
+
+            txn.execute(
+                sql,
+                (
+                    to_key.stream,
+                    room_id,
+                    user_id,
+                ),
+            )
+            for event_id, origin_server_ts in txn:
+                res["event_id"] = event_id
+                res["origin_server_ts"] = origin_server_ts
+
+        await self.db_pool.runInteraction(
+            "beeper_preview_for_room_id_and_user_id",
+            _beeper_preview_for_room_id_and_user_id,
+        )
+
+        return res

--- a/synapse/storage/databases/main/beeper.py
+++ b/synapse/storage/databases/main/beeper.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class BeeperStore(SQLBaseStore):
-    @cached(max_entries=50000, iterable=True)
+    @cached(max_entries=50000, iterable=True, num_args=2, tree=True)
     async def beeper_preview_for_room_id_and_user_id(
         self, room_id: str, user_id: str, to_key: RoomStreamToken
     ) -> JsonDict:

--- a/synapse/storage/databases/main/beeper.py
+++ b/synapse/storage/databases/main/beeper.py
@@ -19,19 +19,37 @@ class BeeperStore(SQLBaseStore):
 
         def _beeper_preview_for_room_id_and_user_id(txn: LoggingTransaction) -> None:
             sql = """
-            SELECT e.event_id, e.origin_server_ts
-                FROM events AS e \
-                LEFT JOIN redactions as r \
+            SELECT e.event_id, COALESCE(re.origin_server_ts, e.origin_server_ts) as origin_server_ts
+            FROM events AS e
+            LEFT JOIN redactions as r
                 ON e.event_id = r.redacts
-            WHERE e.stream_ordering <= ? AND e.room_id = ? \
-            AND (e.type = "m.room.message" \
-            OR e.type = "m.room.encrypted" \
-            OR e.type = "m.reaction") \
-            AND r.redacts IS NULL \
-            AND CASE WHEN (e.type = "m.reaction") \
-                THEN (SELECT ? = ee.sender AND ee.event_id NOT IN (SELECT redacts FROM redactions WHERE redacts = ee.event_id) FROM events as ee \
-                    WHERE ee.event_id = (SELECT er.relates_to_id FROM event_relations AS er \
-                    WHERE er.event_id = e.event_id)) ELSE (true) END
+            -- Join to relations to find replacements
+            LEFT JOIN event_relations as er
+                ON e.event_id = er.event_id AND er.relation_type = 'm.replace'
+            -- Join the original event that was replaced
+            LEFT JOIN events as re
+                ON re.event_id = er.relates_to_id
+            WHERE
+                e.stream_ordering <= ?
+                AND e.room_id = ?
+                AND r.redacts IS NULL
+                AND (
+                    e.type = 'm.room.message'
+                    OR e.type = 'm.room.encrypted'
+                    OR e.type = 'm.reaction'
+                )
+                AND CASE
+                    -- Only find non-redacted reactions to our own messages
+                    WHEN (e.type = 'm.reaction') THEN (
+                        SELECT ? = ee.sender AND ee.event_id NOT IN (
+                            SELECT redacts FROM redactions WHERE redacts = ee.event_id
+                        ) FROM events as ee
+                        WHERE ee.event_id = (
+                            SELECT eer.relates_to_id FROM event_relations AS eer
+                            WHERE eer.event_id = e.event_id
+                        )
+                    )
+                    ELSE (true) END
             ORDER BY stream_ordering DESC
             LIMIT 1
             """

--- a/synapse/storage/databases/main/beeper.py
+++ b/synapse/storage/databases/main/beeper.py
@@ -50,7 +50,7 @@ class BeeperStore(SQLBaseStore):
                         )
                     )
                     ELSE (true) END
-            ORDER BY stream_ordering DESC
+            ORDER BY e.stream_ordering DESC
             LIMIT 1
             """
 

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -231,6 +231,10 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
             "get_unread_event_push_actions_by_room_for_user", (room_id,)
         )
 
+        self._attempt_to_invalidate_cache(
+            "beeper_preview_for_room_id_and_user_id", (room_id,)
+        )
+
         # The `_get_membership_from_event_id` is immutable, except for the
         # case where we look up an event *before* persisting it.
         self._attempt_to_invalidate_cache("_get_membership_from_event_id", (event_id,))

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -809,16 +809,8 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
         receipts.register_servlets,
     ]
 
-    def default_config(self) -> JsonDict:
-        config = super().default_config()
-
-        config["experimental_features"] = {
-            "server_side_room_preview_enabled": True,
-        }
-        return config
-
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
-        self.url = "/sync?since=%s"
+        self.url = "/sync?beeper_previews=true&since=%s"
         self.next_batches = {}
 
         # Register the first user (used to check the unread counts).

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -37,7 +37,6 @@ from tests import unittest
 from tests.federation.transport.test_knocking import (
     KnockingStrippedStateEventHelperMixin,
 )
-
 from tests.server import TimedOutException
 
 
@@ -799,6 +798,7 @@ class UnreadMessagesTestCase(unittest.HomeserverTestCase):
         # Store the next batch for the next request.
         self.next_batch = channel.json_body["next_batch"]
 
+
 class RoomPreviewTestCase(unittest.HomeserverTestCase):
     servlets = [
         synapse.rest.admin.register_servlets,
@@ -819,7 +819,7 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
 
     def prepare(self, reactor: MemoryReactor, clock: Clock, hs: HomeServer) -> None:
         self.url = "/sync?since=%s"
-        self.next_batches = dict()
+        self.next_batches = {}
 
         # Register the first user (used to check the unread counts).
         self.user_id = self.register_user("kermit", "monkey")
@@ -836,7 +836,6 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
         self.user2 = self.register_user("kermit2", "monkey")
         self.tok2 = self.login("kermit2", "monkey")
         self.next_batches[self.tok2] = "s0"
-
 
         # Change the power levels of the room so that the second user can send state
         # events.
@@ -882,7 +881,9 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
                 channel.json_body.get("rooms", {}).get("join", {}).get(room_id, {})
             )
 
-            preview_id = room_entry.get("com.beeper.inbox.preview", {}).get("event_id", {})
+            preview_id = room_entry.get("com.beeper.inbox.preview", {}).get(
+                "event_id", {}
+            )
 
             self.assertEqual(
                 preview_id,
@@ -932,50 +933,67 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
         send_body4 = self.helper.send(self.room_id_4, "hello 4", tok=self.tok2)
 
         # Should have previews for all rooms on first sync.
-        self._check_preview_event_ids(auth_token=self.tok, expected={
-            self.room_id: send_body['event_id'],
-            self.room_id_2: send_body2['event_id'],
-            self.room_id_3: send_body3['event_id'],
-            self.room_id_4: send_body4['event_id']
-        })
+        self._check_preview_event_ids(
+            auth_token=self.tok,
+            expected={
+                self.room_id: send_body["event_id"],
+                self.room_id_2: send_body2["event_id"],
+                self.room_id_3: send_body3["event_id"],
+                self.room_id_4: send_body4["event_id"],
+            },
+        )
 
         # Subsequent - update preview for only room 2"
         send_body5 = self.helper.send(self.room_id_2, "Sup!", tok=self.tok2)
 
-        self._check_preview_event_ids(auth_token=self.tok, expected={
-            self.room_id_2: send_body5['event_id']
-        })
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id_2: send_body5["event_id"]}
+        )
 
     def test_room_preview(self) -> None:
         """Tests that /sync returns a room preview with the latest message for room."""
 
         # One user hello.
-        #Check that a message we send returns a preview in the room (i.e. have multiple clients?)
+        # Check that a message we send returns a preview in the room (i.e. have multiple clients?)
         send_body = self.helper.send(self.room_id, "hello", tok=self.tok)
-        self._check_preview_event_ids(auth_token=self.tok, expected={self.room_id:send_body["event_id"]})
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: send_body["event_id"]}
+        )
 
         # Join new user. Should not show updated preview.
         print("Join user no update preview")
-        connect_body = self.helper.join(room=self.room_id, user=self.user2, tok=self.tok2)
-        self._check_preview_event_ids(auth_token=self.tok, expected={self.room_id:send_body["event_id"]})
+        self.helper.join(room=self.room_id, user=self.user2, tok=self.tok2)
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: send_body["event_id"]}
+        )
 
         print("Second user hello")
         # Check that the new user sending a message updates our preview
         send_2_body = self.helper.send(self.room_id, "hello again!", tok=self.tok2)
-        self._check_preview_event_ids(self.tok, {self.room_id:send_2_body["event_id"]})
+        self._check_preview_event_ids(self.tok, {self.room_id: send_2_body["event_id"]})
 
         print("Encrypted messages 1")
         # Beeper: ensure encrypted messages are treated the same.
-        enc_1_body = self.helper.send_event(self.room_id, EventTypes.Encrypted, {}, tok=self.tok2)
-        self._check_preview_event_ids(auth_token=self.tok, expected={self.room_id:enc_1_body["event_id"]})
+        enc_1_body = self.helper.send_event(
+            self.room_id, EventTypes.Encrypted, {}, tok=self.tok2
+        )
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: enc_1_body["event_id"]}
+        )
 
         print("Encrypted messages 2")
-        enc_2_body = self.helper.send_event(self.room_id, EventTypes.Encrypted, {}, tok=self.tok2)
-        self._check_preview_event_ids(auth_token=self.tok, expected={self.room_id:enc_2_body["event_id"]})
+        enc_2_body = self.helper.send_event(
+            self.room_id, EventTypes.Encrypted, {}, tok=self.tok2
+        )
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: enc_2_body["event_id"]}
+        )
 
         print("Redact encrypted message 2")
-        redact_result = self._redact_event(self.tok2, self.room_id, enc_2_body["event_id"])
-        self._check_preview_event_ids(auth_token=self.tok, expected={self.room_id:enc_1_body["event_id"]})
+        self._redact_event(self.tok2, self.room_id, enc_2_body["event_id"])
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: enc_1_body["event_id"]}
+        )
 
         print("user 2 react to user 1 message")
         # Someone else reacted to my message, update preview.
@@ -991,8 +1009,9 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
             },
             tok=self.tok2,
         )
-        self._check_preview_event_ids(auth_token=self.tok, expected={self.room_id:reaction_1["event_id"]})
-
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: reaction_1["event_id"]}
+        )
 
         print("User 1 react to User 2 message.")
         # Not a reaction to my message, don't update preview.
@@ -1008,16 +1027,23 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
             },
             tok=self.tok,
         )
-        self._check_preview_event_ids(auth_token=self.tok, expected={self.room_id:reaction_1["event_id"]})
-        self._check_preview_event_ids(auth_token=self.tok2, expected={self.room_id:reaction_2["event_id"]})
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: reaction_1["event_id"]}
+        )
+        self._check_preview_event_ids(
+            auth_token=self.tok2, expected={self.room_id: reaction_2["event_id"]}
+        )
 
         print("Redact user 2 message with reactions.")
         # Remove redactions as well as reactions from user 2's preview.
-        redact_result_2 = self._redact_event(self.tok2, self.room_id,
-                                           send_2_body["event_id"])
+        self._redact_event(self.tok2, self.room_id, send_2_body["event_id"])
 
-        self._check_preview_event_ids(auth_token=self.tok, expected={self.room_id:reaction_1["event_id"]})
-        self._check_preview_event_ids(auth_token=self.tok2,expected={self.room_id:enc_1_body["event_id"]})
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: reaction_1["event_id"]}
+        )
+        self._check_preview_event_ids(
+            auth_token=self.tok2, expected={self.room_id: enc_1_body["event_id"]}
+        )
 
 
 class SyncCacheTestCase(unittest.HomeserverTestCase):

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -953,7 +953,7 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
     def test_room_preview(self) -> None:
         """Tests that /sync returns a room preview with the latest message for room."""
 
-        # One user hello.
+        # One user says hello.
         # Check that a message we send returns a preview in the room (i.e. have multiple clients?)
         send_body = self.helper.send(self.room_id, "hello", tok=self.tok)
         self._check_preview_event_ids(
@@ -961,18 +961,17 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
         )
 
         # Join new user. Should not show updated preview.
-        print("Join user no update preview")
         self.helper.join(room=self.room_id, user=self.user2, tok=self.tok2)
         self._check_preview_event_ids(
             auth_token=self.tok, expected={self.room_id: send_body["event_id"]}
         )
 
-        print("Second user hello")
+        # Second user says hello
         # Check that the new user sending a message updates our preview
         send_2_body = self.helper.send(self.room_id, "hello again!", tok=self.tok2)
         self._check_preview_event_ids(self.tok, {self.room_id: send_2_body["event_id"]})
 
-        print("Encrypted messages 1")
+        # Encrypted messages 1
         # Beeper: ensure encrypted messages are treated the same.
         enc_1_body = self.helper.send_event(
             self.room_id, EventTypes.Encrypted, {}, tok=self.tok2
@@ -981,7 +980,7 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
             auth_token=self.tok, expected={self.room_id: enc_1_body["event_id"]}
         )
 
-        print("Encrypted messages 2")
+        # Encrypted messages 2
         enc_2_body = self.helper.send_event(
             self.room_id, EventTypes.Encrypted, {}, tok=self.tok2
         )
@@ -989,13 +988,13 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
             auth_token=self.tok, expected={self.room_id: enc_2_body["event_id"]}
         )
 
-        print("Redact encrypted message 2")
+        # Redact encrypted message 2
         self._redact_event(self.tok2, self.room_id, enc_2_body["event_id"])
         self._check_preview_event_ids(
             auth_token=self.tok, expected={self.room_id: enc_1_body["event_id"]}
         )
 
-        print("user 2 react to user 1 message")
+        # User 2 react to user 1 message
         # Someone else reacted to my message, update preview.
         reaction_1 = self.helper.send_event(
             room_id=self.room_id,
@@ -1013,7 +1012,7 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
             auth_token=self.tok, expected={self.room_id: reaction_1["event_id"]}
         )
 
-        print("User 1 react to User 2 message.")
+        # User 1 react to User 2 message.
         # Not a reaction to my message, don't update preview.
         reaction_2 = self.helper.send_event(
             room_id=self.room_id,
@@ -1034,7 +1033,7 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
             auth_token=self.tok2, expected={self.room_id: reaction_2["event_id"]}
         )
 
-        print("Redact user 2 message with reactions.")
+        # Redact user 2 message with reactions.
         # Remove redactions as well as reactions from user 2's preview.
         self._redact_event(self.tok2, self.room_id, send_2_body["event_id"])
 


### PR DESCRIPTION
Based on the wonderful work by Liam in https://github.com/beeper/synapse/pull/36.

Available behind a query string param `?beeper_previews=true` with cache invalidation over replication on new events. Uses an in memory tree cache which can't currently be Redis backed, but the low number of rows returned should mean this doesn't have serious database impact on cold starts.