### PR TITLE
Clear push actions on tombstone

### DIFF
--- a/synapse/handlers/room.py
+++ b/synapse/handlers/room.py
@@ -340,6 +340,9 @@ class RoomCreationHandler:
             old_room_state,
         )
 
+        # Beeper: clear out any push actions and summaries for this room
+        await self.store.beeper_cleanup_tombstoned_room(old_room_id)
+
         return new_room_id
 
     async def _update_upgraded_room_pls(

--- a/synapse/storage/databases/main/beeper.py
+++ b/synapse/storage/databases/main/beeper.py
@@ -68,3 +68,17 @@ class BeeperStore(SQLBaseStore):
             "beeper_preview_for_room_id_and_user_id",
             beeper_preview_txn,
         )
+
+    async def beeper_cleanup_tombstoned_room(self, room_id: str) -> None:
+        def beeper_cleanup_tombstoned_room_txn(txn: LoggingTransaction) -> None:
+            self.db_pool.simple_delete_txn(
+                txn, table="event_push_actions", keyvalues={"room_id": room_id}
+            )
+            self.db_pool.simple_delete_txn(
+                txn, table="event_push_summary", keyvalues={"room_id": room_id}
+            )
+
+        await self.db_pool.runInteraction(
+            "beeper_cleanup_tombstoned_room",
+            beeper_cleanup_tombstoned_room_txn,
+        )


### PR DESCRIPTION
Aim is to fix push badge counts. Tombstoned rooms are hidden in Beeper so we also wish to clear out any leftover notificatons/unreads as these can never be cleared.