### PR TITLE
Update Beeper preview query to correctly handle edit events

### DIFF
--- a/synapse/handlers/sync.py
+++ b/synapse/handlers/sync.py
@@ -2470,7 +2470,8 @@ class SyncHandler:
                     preview={},
                 )
 
-                if sync_config.beeper_previews:
+                # Only generate previews if we have new events that would change it
+                if batch.events and sync_config.beeper_previews:
                     preview = (
                         await self.store.beeper_preview_event_for_room_id_and_user_id(
                             room_id=room_id, user_id=user_id, to_key=now_token.room_key

--- a/synapse/storage/databases/main/beeper.py
+++ b/synapse/storage/databases/main/beeper.py
@@ -89,7 +89,7 @@ class BeeperStore(SQLBaseStore):
                 LEFT JOIN event_relations as er
                     ON e.event_id = er.relates_to_id AND er.relation_type = 'm.replace'
                 LEFT JOIN events as e_replacement
-                    ON er.relates_to_id = e_replacement.event_id
+                    ON er.event_id = e_replacement.event_id
                 ORDER BY e_replacement.origin_server_ts DESC
                 LIMIT 1
             )

--- a/synapse/storage/databases/main/beeper.py
+++ b/synapse/storage/databases/main/beeper.py
@@ -11,7 +11,6 @@ from synapse.storage.database import (
     LoggingTransaction,
 )
 from synapse.types import RoomStreamToken
-from synapse.util.caches.descriptors import cached
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer
@@ -41,7 +40,6 @@ class BeeperStore(SQLBaseStore):
             )
             self.is_aggregating_notification_counts = False
 
-    @cached(max_entries=50000, num_args=2, tree=True)
     async def beeper_preview_event_for_room_id_and_user_id(
         self, room_id: str, user_id: str, to_key: RoomStreamToken
     ) -> Optional[Tuple[str, int]]:

--- a/synapse/storage/databases/main/cache.py
+++ b/synapse/storage/databases/main/cache.py
@@ -236,10 +236,6 @@ class CacheInvalidationWorkerStore(SQLBaseStore):
             "get_unread_event_push_actions_by_room_for_user", (room_id,)
         )
 
-        self._attempt_to_invalidate_cache(
-            "beeper_preview_event_for_room_id_and_user_id", (room_id,)
-        )
-
         # The `_get_membership_from_event_id` is immutable, except for the
         # case where we look up an event *before* persisting it.
         self._attempt_to_invalidate_cache("_get_membership_from_event_id", (event_id,))

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -799,7 +799,7 @@ class UnreadMessagesTestCase(unittest.HomeserverTestCase):
         self.next_batch = channel.json_body["next_batch"]
 
 
-class RoomPreviewTestCase(unittest.HomeserverTestCase):
+class BeeperRoomPreviewTestCase(unittest.HomeserverTestCase):
     servlets = [
         synapse.rest.admin.register_servlets,
         login.register_servlets,
@@ -1035,6 +1035,61 @@ class RoomPreviewTestCase(unittest.HomeserverTestCase):
         self._check_preview_event_ids(
             auth_token=self.tok2, expected={self.room_id: enc_1_body["event_id"]}
         )
+
+    def test_room_preview_edits(self) -> None:
+        """Tests that /sync returns a room preview with the latest message for room."""
+
+        # One user says hello.
+        # Check that a message we send returns a preview in the room (i.e. have multiple clients?)
+        send_body = self.helper.send(self.room_id, "hello", tok=self.tok)
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: send_body["event_id"]}
+        )
+
+        # Join new user. Should not show updated preview.
+        self.helper.join(room=self.room_id, user=self.user2, tok=self.tok2)
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: send_body["event_id"]}
+        )
+
+        # Second user says hello
+        # Check that the new user sending a message updates our preview
+        send_2_body = self.helper.send(self.room_id, "hello again!", tok=self.tok2)
+        self._check_preview_event_ids(self.tok, {self.room_id: send_2_body["event_id"]})
+
+        # First user edits their old message
+        # Check that this doesn't alter the preview
+        self.helper.send_event(
+            room_id=self.room_id,
+            type=EventTypes.Message,
+            content={
+                "body": "hello edit",
+                "msgtype": "m.text",
+                "m.relates_to": {
+                    "rel_type": RelationTypes.REPLACE,
+                    "event_id": send_body["event_id"],
+                },
+            },
+            tok=self.tok,
+        )
+        self._check_preview_event_ids(self.tok, {self.room_id: send_2_body["event_id"]})
+
+        # Now second user edits their (currently preview) message
+        # Check that this does become the preview
+        send_3_body = self.helper.send_event(
+            room_id=self.room_id,
+            type=EventTypes.Message,
+            content={
+                "body": "hello edit",
+                "msgtype": "m.text",
+                "m.relates_to": {
+                    "rel_type": RelationTypes.REPLACE,
+                    "event_id": send_2_body["event_id"],
+                },
+            },
+            tok=self.tok2,
+        )
+        self._check_preview_event_ids(self.tok, {self.room_id: send_3_body["event_id"]})
 
 
 class SyncCacheTestCase(unittest.HomeserverTestCase):

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -1091,6 +1091,29 @@ class BeeperRoomPreviewTestCase(unittest.HomeserverTestCase):
         )
         self._check_preview_event_ids(self.tok, {self.room_id: send_3_body["event_id"]})
 
+        # Now second user edits their (currently preview) message again
+        # Check that this does become the preview, over the previous edit
+        send_4_body = self.helper.send_event(
+            room_id=self.room_id,
+            type=EventTypes.Message,
+            content={
+                "body": "hello edit 2",
+                "msgtype": "m.text",
+                "m.relates_to": {
+                    "rel_type": RelationTypes.REPLACE,
+                    "event_id": send_2_body["event_id"],
+                },
+            },
+            tok=self.tok2,
+        )
+        self._check_preview_event_ids(self.tok, {self.room_id: send_4_body["event_id"]})
+
+        # Finally, first user sends a message and this should become the preview
+        send_5_body = self.helper.send(self.room_id, "hello", tok=self.tok)
+        self._check_preview_event_ids(
+            auth_token=self.tok, expected={self.room_id: send_5_body["event_id"]}
+        )
+
 
 class SyncCacheTestCase(unittest.HomeserverTestCase):
     servlets = [


### PR DESCRIPTION
We first want to ignore edit events from potential preview events as these often replace events further back in history but come mots recent on order.

We then do a second join for edit events that replace the selected (non edit) preview event, and use where present, meaning edits on the latest preview event show correctly.
