### PR TITLE
Use `docker tag` to push latest tag

### DIFF
--- a/.github/workflows/beeper-ci.yml
+++ b/.github/workflows/beeper-ci.yml
@@ -96,13 +96,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: |-
+      - id: generate-docker-tag
+        run: |-
           if [ "${{ github.ref_name }}" = "beeper" ]; then
             tag=$(cat pyproject.toml | grep -E "^version =" | sed -E 's/^version = "(.+)"$/\1/')
           else
             tag="${{ github.head_ref || github.ref_name }}"
           fi
-          echo "tag_base=$tag" >> $GITHUB_ENV
+          echo "tag_base=$tag" >> $GITHUB_OUTPUT
 
   build-python:
     needs:
@@ -123,13 +124,13 @@ jobs:
           docker buildx build \
             --push \
             --platform linux/amd64 \
-            --tag ${{ secrets.CI_REGISTRY }}/synapse:${{ env.tag_base }}-${{ github.sha }} \
+            --tag ${{ secrets.CI_REGISTRY }}/synapse:${{ steps.generate-docker-tag.outputs.tag_base }}-${{ github.sha }} \
             -f docker/Dockerfile \
             .
 
           if [ "${{ github.ref_name }}" = "beeper" ]; then
             docker tag \
-              ${{ secrets.CI_REGISTRY }}/synapse:${{ env.tag_base }}-${{ github.sha }} \
+              ${{ secrets.CI_REGISTRY }}/synapse:${{ steps.generate-docker-tag.outputs.tag_base }}-${{ github.sha }} \
               ${{ secrets.CI_REGISTRY }}/synapse:latest
             docker push ${{ secrets.CI_REGISTRY }}/synapse:latest
           fi
@@ -137,10 +138,10 @@ jobs:
           # Ensure the image works properly
           docker run \
             --entrypoint '' \
-            ${{ secrets.CI_REGISTRY }}/synapse:${{ env.tag_base }}-${{ github.sha }} \
+            ${{ secrets.CI_REGISTRY }}/synapse:${{ steps.generate-docker-tag.outputs.tag_base }}-${{ github.sha }} \
             python -m synapse.app.homeserver --help
 
-          echo "Pushed image: synapse:${{ env.tag_base }}-${{ github.sha }}"
+          echo "Pushed image: synapse:${{ steps.generate-docker-tag.outputs.tag_base }}-${{ github.sha }}"
           if [ "${{ github.ref_name }}" = "beeper" ]; then
             echo "Pushed image: synapse:latest"
           fi
@@ -166,14 +167,14 @@ jobs:
             --platform linux/amd64 \
             --build-arg PYTHON_PREFIX=/usr \
             --build-arg BASE_IMAGE=${{ secrets.CI_REGISTRY }}/pyston-no-pymalloc:slim-amd64-2.3.4 \
-            --tag ${{ secrets.CI_REGISTRY }}/synapse:${{ env.tag_base }}-${{ github.sha }}-pyston \
+            --tag ${{ secrets.CI_REGISTRY }}/synapse:${{ steps.generate-docker-tag.outputs.tag_base }}-${{ github.sha }}-pyston \
             -f docker/Dockerfile \
             .
 
           # Ensure the image works properly
           docker run \
             --entrypoint '' \
-            ${{ secrets.CI_REGISTRY }}/synapse:${{ env.tag_base }}-${{ github.sha }}-pyston \
+            ${{ secrets.CI_REGISTRY }}/synapse:${{ steps.generate-docker-tag.outputs.tag_base }}-${{ github.sha }}-pyston \
             python -m synapse.app.homeserver --help
 
-          echo "Pushed image: synapse:${{ env.tag_base }}-${{ github.sha }}-pyston"
+          echo "Pushed image: synapse:${{ steps.generate-docker-tag.outputs.tag_base }}-${{ github.sha }}-pyston"

--- a/.github/workflows/beeper-ci.yml
+++ b/.github/workflows/beeper-ci.yml
@@ -92,22 +92,7 @@ jobs:
 
   # Builds
 
-  generate-docker-tag:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - id: generate-docker-tag
-        run: |-
-          if [ "${{ github.ref_name }}" = "beeper" ]; then
-            tag=$(cat pyproject.toml | grep -E "^version =" | sed -E 's/^version = "(.+)"$/\1/')
-          else
-            tag="${{ github.head_ref || github.ref_name }}"
-          fi
-          echo "tag_base=$tag" >> $GITHUB_OUTPUT
-
   build-python:
-    needs:
-      - generate-docker-tag
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
@@ -121,16 +106,22 @@ jobs:
           username: ${{ secrets.CI_REGISTRY_USER }}
           password: ${{ secrets.CI_REGISTRY_PASSWORD }}
       - run: |-
+          if [ "${{ github.ref_name }}" = "beeper" ]; then
+            tag=$(cat pyproject.toml | grep -E "^version =" | sed -E 's/^version = "(.+)"$/\1/')
+          else
+            tag="${{ github.head_ref || github.ref_name }}"
+          fi
+
           docker buildx build \
             --push \
             --platform linux/amd64 \
-            --tag ${{ secrets.CI_REGISTRY }}/synapse:${{ steps.generate-docker-tag.outputs.tag_base }}-${{ github.sha }} \
+            --tag ${{ secrets.CI_REGISTRY }}/synapse:$tag-${{ github.sha }} \
             -f docker/Dockerfile \
             .
 
           if [ "${{ github.ref_name }}" = "beeper" ]; then
             docker tag \
-              ${{ secrets.CI_REGISTRY }}/synapse:${{ steps.generate-docker-tag.outputs.tag_base }}-${{ github.sha }} \
+              ${{ secrets.CI_REGISTRY }}/synapse:$tag-${{ github.sha }} \
               ${{ secrets.CI_REGISTRY }}/synapse:latest
             docker push ${{ secrets.CI_REGISTRY }}/synapse:latest
           fi
@@ -138,17 +129,15 @@ jobs:
           # Ensure the image works properly
           docker run \
             --entrypoint '' \
-            ${{ secrets.CI_REGISTRY }}/synapse:${{ steps.generate-docker-tag.outputs.tag_base }}-${{ github.sha }} \
+            ${{ secrets.CI_REGISTRY }}/synapse:$tag-${{ github.sha }} \
             python -m synapse.app.homeserver --help
 
-          echo "Pushed image: synapse:${{ steps.generate-docker-tag.outputs.tag_base }}-${{ github.sha }}"
+          echo "Pushed image: synapse:$tag-${{ github.sha }}"
           if [ "${{ github.ref_name }}" = "beeper" ]; then
             echo "Pushed image: synapse:latest"
           fi
 
   build-pyston:
-    needs:
-      - generate-docker-tag
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
@@ -162,19 +151,25 @@ jobs:
           username: ${{ secrets.CI_REGISTRY_USER }}
           password: ${{ secrets.CI_REGISTRY_PASSWORD }}
       - run: |-
+          if [ "${{ github.ref_name }}" = "beeper" ]; then
+            tag=$(cat pyproject.toml | grep -E "^version =" | sed -E 's/^version = "(.+)"$/\1/')
+          else
+            tag="${{ github.head_ref || github.ref_name }}"
+          fi
+
           docker buildx build \
             --push \
             --platform linux/amd64 \
             --build-arg PYTHON_PREFIX=/usr \
             --build-arg BASE_IMAGE=${{ secrets.CI_REGISTRY }}/pyston-no-pymalloc:slim-amd64-2.3.4 \
-            --tag ${{ secrets.CI_REGISTRY }}/synapse:${{ steps.generate-docker-tag.outputs.tag_base }}-${{ github.sha }}-pyston \
+            --tag ${{ secrets.CI_REGISTRY }}/synapse:$tag-${{ github.sha }}-pyston \
             -f docker/Dockerfile \
             .
 
           # Ensure the image works properly
           docker run \
             --entrypoint '' \
-            ${{ secrets.CI_REGISTRY }}/synapse:${{ steps.generate-docker-tag.outputs.tag_base }}-${{ github.sha }}-pyston \
+            ${{ secrets.CI_REGISTRY }}/synapse:$tag-${{ github.sha }}-pyston \
             python -m synapse.app.homeserver --help
 
-          echo "Pushed image: synapse:${{ steps.generate-docker-tag.outputs.tag_base }}-${{ github.sha }}-pyston"
+          echo "Pushed image: synapse:$tag-${{ github.sha }}-pyston"

--- a/.github/workflows/beeper-ci.yml
+++ b/.github/workflows/beeper-ci.yml
@@ -92,7 +92,21 @@ jobs:
 
   # Builds
 
+  generate-docker-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |-
+          if [ "${{ github.ref_name }}" = "beeper" ]; then
+            tag=$(cat pyproject.toml | grep -E "^version =" | sed -E 's/^version = "(.+)"$/\1/')
+          else
+            tag="${{ github.head_ref || github.ref_name }}"
+          fi
+          echo "tag_base=$tag" >> $GITHUB_ENV
+
   build-python:
+    needs:
+      - generate-docker-tag
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
@@ -106,34 +120,34 @@ jobs:
           username: ${{ secrets.CI_REGISTRY_USER }}
           password: ${{ secrets.CI_REGISTRY_PASSWORD }}
       - run: |-
-          if [ "${{ github.ref_name }}" = "beeper" ]; then
-            tag=$(cat pyproject.toml | grep -E "^version =" | sed -E 's/^version = "(.+)"$/\1/')
-            extraTag="--tag ${{ secrets.CI_REGISTRY }}/synapse:latest"
-          else
-            tag="${{ github.head_ref || github.ref_name }}"
-            extraTag=""
-          fi
-
           docker buildx build \
             --push \
             --platform linux/amd64 \
-            --tag ${{ secrets.CI_REGISTRY }}/synapse:$tag-${{ github.sha }} \
-            $extraTag \
+            --tag ${{ secrets.CI_REGISTRY }}/synapse:${{ env.tag_base }}-${{ github.sha }} \
             -f docker/Dockerfile \
             .
+
+          if [ "${{ github.ref_name }}" = "beeper" ]; then
+            docker tag \
+              ${{ secrets.CI_REGISTRY }}/synapse:${{ env.tag_base }}-${{ github.sha }} \
+              ${{ secrets.CI_REGISTRY }}/synapse:latest
+            docker push ${{ secrets.CI_REGISTRY }}/synapse:latest
+          fi
 
           # Ensure the image works properly
           docker run \
             --entrypoint '' \
-            ${{ secrets.CI_REGISTRY }}/synapse:$tag-${{ github.sha }} \
+            ${{ secrets.CI_REGISTRY }}/synapse:${{ env.tag_base }}-${{ github.sha }} \
             python -m synapse.app.homeserver --help
 
-          echo "Pushed image: synapse:$tag-${{ github.sha }}"
+          echo "Pushed image: synapse:${{ env.tag_base }}-${{ github.sha }}"
           if [ "${{ github.ref_name }}" = "beeper" ]; then
             echo "Pushed image: synapse:latest"
           fi
 
   build-pyston:
+    needs:
+      - generate-docker-tag
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
@@ -147,25 +161,19 @@ jobs:
           username: ${{ secrets.CI_REGISTRY_USER }}
           password: ${{ secrets.CI_REGISTRY_PASSWORD }}
       - run: |-
-          if [ "${{ github.ref_name }}" = "beeper" ]; then
-            tag=$(cat pyproject.toml | grep -E "^version =" | sed -E 's/^version = "(.+)"$/\1/');
-          else
-            tag="${{ github.head_ref || github.ref_name }}";
-          fi
-
           docker buildx build \
             --push \
             --platform linux/amd64 \
             --build-arg PYTHON_PREFIX=/usr \
             --build-arg BASE_IMAGE=${{ secrets.CI_REGISTRY }}/pyston-no-pymalloc:slim-amd64-2.3.4 \
-            --tag ${{ secrets.CI_REGISTRY }}/synapse:$tag-${{ github.sha }}-pyston \
+            --tag ${{ secrets.CI_REGISTRY }}/synapse:${{ env.tag_base }}-${{ github.sha }}-pyston \
             -f docker/Dockerfile \
             .
 
           # Ensure the image works properly
           docker run \
             --entrypoint '' \
-            ${{ secrets.CI_REGISTRY }}/synapse:$tag-${{ github.sha }}-pyston \
+            ${{ secrets.CI_REGISTRY }}/synapse:${{ env.tag_base }}-${{ github.sha }}-pyston \
             python -m synapse.app.homeserver --help
 
-          echo "Pushed image: synapse:$tag-${{ github.sha }}-pyston"
+          echo "Pushed image: synapse:${{ env.tag_base }}-${{ github.sha }}-pyston"

--- a/.github/workflows/beeper-ci.yml
+++ b/.github/workflows/beeper-ci.yml
@@ -100,6 +100,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
+        with:
+          # TEMPORARY, see: https://github.com/docker/build-push-action/issues/761
+          driver-opts: |
+            image=moby/buildkit:v0.10.6
       - uses: docker/login-action@v2
         with:
           registry: ${{ secrets.CI_REGISTRY }}
@@ -145,6 +149,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
+        with:
+          # TEMPORARY, see: https://github.com/docker/build-push-action/issues/761
+          driver-opts: |
+            image=moby/buildkit:v0.10.6
       - uses: docker/login-action@v2
         with:
           registry: ${{ secrets.CI_REGISTRY }}


### PR DESCRIPTION
This allows pulling the latest tag on different architectures than amd64 because docker and docker buildx behave differently. I hate docker.