### PR TITLE
No read receipts in large rooms

### DIFF
--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -274,7 +274,6 @@ class ReceiptTypes:
     READ: Final = "m.read"
     READ_PRIVATE: Final = "m.read.private"
     FULLY_READ: Final = "m.fully_read"
-    BEEPER_INBOX_DONE: Final = "com.beeper.inbox.done"
 
 
 RECEIPTS_MAX_ROOM_SIZE = 100

--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -277,6 +277,9 @@ class ReceiptTypes:
     BEEPER_INBOX_DONE: Final = "com.beeper.inbox.done"
 
 
+RECEIPTS_MAX_ROOM_SIZE = 100
+
+
 class PublicRoomsFilterFields:
     """Fields in the search filter for `/publicRooms` that we understand.
 

--- a/synapse/handlers/receipts.py
+++ b/synapse/handlers/receipts.py
@@ -125,7 +125,7 @@ class ReceiptsHandler:
 
         room_sizes = await yieldable_gather_results(
             lambda room_id: self.store.get_number_joined_users_in_room(room_id),
-            (room_id for room_id in room_ids_to_check)
+            (room_id for room_id in room_ids_to_check),
         )
         large_rooms = []
         for room_id, room_size in zip(room_ids_to_check, room_sizes):

--- a/synapse/handlers/receipts.py
+++ b/synapse/handlers/receipts.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple
 
 from synapse.api.constants import RECEIPTS_MAX_ROOM_SIZE, EduTypes, ReceiptTypes
 from synapse.appservice import ApplicationService
-from synapse.util.async_helpers import yieldable_gather_results
 from synapse.streams import EventSource
 from synapse.types import (
     JsonDict,
@@ -25,6 +24,7 @@ from synapse.types import (
     UserID,
     get_domain_from_id,
 )
+from synapse.util.async_helpers import yieldable_gather_results
 
 if TYPE_CHECKING:
     from synapse.server import HomeServer

--- a/synapse/rest/client/notifications.py
+++ b/synapse/rest/client/notifications.py
@@ -61,7 +61,6 @@ class NotificationsServlet(RestServlet):
             user_id,
             [
                 ReceiptTypes.READ,
-                ReceiptTypes.BEEPER_INBOX_DONE,
                 ReceiptTypes.READ_PRIVATE,
             ],
         )

--- a/synapse/rest/client/receipts.py
+++ b/synapse/rest/client/receipts.py
@@ -49,7 +49,6 @@ class ReceiptRestServlet(RestServlet):
             ReceiptTypes.READ,
             ReceiptTypes.READ_PRIVATE,
             ReceiptTypes.FULLY_READ,
-            ReceiptTypes.BEEPER_INBOX_DONE,
         }
 
     async def on_POST(

--- a/synapse/storage/databases/main/roommember.py
+++ b/synapse/storage/databases/main/roommember.py
@@ -349,7 +349,7 @@ class RoomMemberWorkerStore(EventsWorkerStore):
             "get_room_summary", _get_room_summary_txn
         )
 
-    @cached()
+    @cached(max_entries=100000)
     async def get_number_joined_users_in_room(self, room_id: str) -> int:
         return await self.db_pool.simple_select_one_onecol(
             table="current_state_events",

--- a/synapse/types/__init__.py
+++ b/synapse/types/__init__.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import abc
 import re
 import string
@@ -52,6 +54,7 @@ from twisted.internet.interfaces import (
     IReactorTime,
 )
 
+from synapse.api.constants import ReceiptTypes
 from synapse.api.errors import Codes, SynapseError
 from synapse.util.cancellation import cancellable
 from synapse.util.stringutils import parse_and_validate_server_name
@@ -852,6 +855,19 @@ class ReadReceipt:
     event_ids: List[str]
     thread_id: Optional[str]
     data: JsonDict
+
+    # Beeper: we don't want to alter the frozen attr, but
+    # do occasionally need to make a private copy to
+    # avoid traffic to large rooms.
+    def make_private_copy(self) -> ReadReceipt:
+        return ReadReceipt(
+            room_id=self.room_id,
+            user_id=self.user_id,
+            event_ids=self.event_ids,
+            thread_id=self.thread_id,
+            data=self.data,
+            receipt_type=ReceiptTypes.READ_PRIVATE,
+        )
 
 
 @attr.s(slots=True, frozen=True, auto_attribs=True)

--- a/tests/rest/client/test_sync.py
+++ b/tests/rest/client/test_sync.py
@@ -22,6 +22,7 @@ from twisted.test.proto_helpers import MemoryReactor
 
 import synapse.rest.admin
 from synapse.api.constants import (
+    RECEIPTS_MAX_ROOM_SIZE,
     EduTypes,
     EventContentFields,
     EventTypes,
@@ -382,6 +383,7 @@ class ReadReceiptsTestCase(unittest.HomeserverTestCase):
     servlets = [
         synapse.rest.admin.register_servlets,
         login.register_servlets,
+        read_marker.register_servlets,
         receipts.register_servlets,
         room.register_servlets,
         sync.register_servlets,
@@ -498,6 +500,35 @@ class ReadReceiptsTestCase(unittest.HomeserverTestCase):
         )
         self.assertEqual(channel.code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(channel.json_body["errcode"], "M_NOT_JSON", channel.json_body)
+
+    def test_read_receipt_not_sent_to_large_rooms(self) -> None:
+        # Beeper: we don't send read receipts on rooms with more
+        # users than # RECEIPTS_MAX_ROOM_SIZE
+        for i in range(RECEIPTS_MAX_ROOM_SIZE):
+            user = self.register_user(f"user_{i}", f"secure_password_{i}")
+            tok = self.login(f"user_{i}", f"secure_password_{i}")
+            self.helper.join(room=self.room_id, user=user, tok=tok)
+
+        res = self.helper.send(
+            self.room_id, body="woah, this is a big room!", tok=self.tok
+        )
+
+        for receipt_type in (
+            ReceiptTypes.FULLY_READ,
+            ReceiptTypes.READ_PRIVATE,
+            ReceiptTypes.READ,
+        ):
+            # Send a read receipt
+            channel = self.make_request(
+                "POST",
+                f"/rooms/{self.room_id}/receipt/{receipt_type}/{res['event_id']}",
+                {},
+                access_token=self.tok2,
+            )
+            self.assertEqual(channel.code, 200)
+
+            # Test that we didn't get a read receipt.
+            self.assertIsNone(self._get_read_receipt())
 
     def _get_read_receipt(self) -> Optional[JsonDict]:
         """Syncs and returns the read receipt."""
@@ -727,6 +758,15 @@ class UnreadMessagesTestCase(unittest.HomeserverTestCase):
         )
         self.assertEqual(channel.code, 200, channel.json_body)
         self._check_unread_count(0)
+
+    def test_large_rooms_dont_alter_unread_count_behaviour(self) -> None:
+        # Beeper: create a lot of users and join them to the room
+        for i in range(RECEIPTS_MAX_ROOM_SIZE):
+            user = self.register_user(f"user_{i}", f"secure_password_{i}")
+            tok = self.login(f"user_{i}", f"secure_password_{i}")
+            self.helper.join(self.room_id, user=user, tok=tok)
+
+        self.test_unread_counts()
 
     # We test for all three receipt types that influence notification counts
     @parameterized.expand(


### PR DESCRIPTION
## Overview
Prevents read receipts being sent when rooms are over a defined size, whilst preserving the behaviour of read/unread notifications. This has been achieved by converting receipts types to be private when the room size is large, as this is the simplest method I've found to decouple ephemeral receipt notification and read/unread notifications.
