### PR TITLE
Add JWT support for user-interactive flows

### DIFF
--- a/synapse/api/constants.py
+++ b/synapse/api/constants.py
@@ -84,6 +84,7 @@ class LoginType:
     SSO: Final = "m.login.sso"
     DUMMY: Final = "m.login.dummy"
     REGISTRATION_TOKEN: Final = "m.login.registration_token"
+    JWT: Final = "org.matrix.login.jwt"
 
 
 # This is used in the `type` parameter for /register when called by

--- a/synapse/handlers/auth.py
+++ b/synapse/handlers/auth.py
@@ -413,6 +413,10 @@ class AuthHandler:
         ):
             ui_auth_types.add(LoginType.SSO)
 
+        # if JWT is enabled, allow user to re-authenticate with one
+        if self.hs.config.jwt.jwt_enabled:
+            ui_auth_types.add(LoginType.JWT)
+
         return ui_auth_types
 
     def get_enabled_auth_types(self) -> Iterable[str]:


### PR DESCRIPTION
This duplicates the login JWT type as an auth checker for interactive flows.

Fixes BE-7554