### PR TITLE
set read_marker from inbox_state endpoint

### DIFF
--- a/synapse/rest/client/account_data.py
+++ b/synapse/rest/client/account_data.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 from typing import TYPE_CHECKING, Tuple
 
@@ -325,6 +326,9 @@ class RoomBeeperInboxStateServlet(RestServlet):
         if "read_markers" in body:
             await self.read_marker_client.handle_read_marker(
                 room_id, body["read_markers"], requester
+            )
+            logger.info(
+                f"SetBeeperReadMarkers read_markers={json.dumps(body['read_markers'])}"
             )
 
         return 200, {}


### PR DESCRIPTION
Read markers can now be set on `inbox_state`, with the same payload as using `read_markers` but with the key `read_markers` e.g.
```json
{
    "done": {"at_delta": 300000 },
    "marked_unread": false,
    "read_markers": {
        "m.read.fully_read": "<event-id>",
        "m.read.read": "<event-id>",
        "m.read.private": "<event-id>",
    }
}
```
https://linear.app/beeper/issue/BE-11353/synapse-enable-setting-read-markers-on-inbox-state

This is the synapse counter part to https://github.com/beeper/hungryserv/pull/141